### PR TITLE
parse with xcrun and add sorting

### DIFF
--- a/OpenSim.xcodeproj/project.pbxproj
+++ b/OpenSim.xcodeproj/project.pbxproj
@@ -273,6 +273,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = OpenSim/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.pop-tap.OpenSim";
 				PRODUCT_NAME = OpenSim;
 			};
@@ -285,6 +286,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = OpenSim/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.pop-tap.OpenSim";
 				PRODUCT_NAME = OpenSim;
 			};

--- a/OpenSim/AppDelegate.swift
+++ b/OpenSim/AppDelegate.swift
@@ -66,9 +66,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func buildMenu() {
         statusItem.menu!.removeAllItems()
         
-        DeviceManager.defaultManager.reload()
-        let iOSDevices = DeviceManager.defaultManager.deviceMapping.filter { $0.0.containsString("iOS") }.flatMap { $0.1 }
+        // extract devices and sort based on runtime version so latest is on the bottom
+        DeviceManager.defaultManager.reload2()
+        let iOSDevices = DeviceManager.defaultManager.deviceMapping
+
+        var currentRuntime = ""
         iOSDevices.forEach { device in
+            if (currentRuntime != "" && device.runtime.name != currentRuntime) {
+                // add filler
+                statusItem.menu?.addItemWithTitle("", action: nil, keyEquivalent: "")
+            }
+            
+            currentRuntime = device.runtime.name
+            
             let deviceMenuItem = statusItem.menu?.addItemWithTitle("\(device.name) (\(device.runtime))", action: nil, keyEquivalent: "")
             deviceMenuItem?.onStateImage = NSImage(named: "active")
             deviceMenuItem?.offStateImage = NSImage(named: "inactive")

--- a/OpenSim/DeviceManager.swift
+++ b/OpenSim/DeviceManager.swift
@@ -14,39 +14,111 @@ final class DeviceManager {
     static let deviceRuntimePrefix = "com.apple.CoreSimulator.SimRuntime"
     
     static let defaultManager = DeviceManager()
-    var deviceMapping = [String: [Device]]()
+    var deviceMapping = [Device]()
     
-    func reload() {
-        guard let devicesPlist = NSDictionary(contentsOfURL: URLHelper.deviceSetURL)?[DeviceManager.devicesKey] as? [String: AnyObject] else {
-            return
-        }
-        let filteredDevice = devicesPlist.filter { (key, _) -> Bool in key.hasPrefix(DeviceManager.deviceRuntimePrefix) }
-        var mapping = [String: [Device]]()
-        filteredDevice.forEach { (key, value) -> () in
-            if let deviceList = value as? [String: String] {
-                let devices = deviceList.map { (_, UDID) -> Device? in
-                    let URL = URLHelper.deviceURLForUDID(UDID).URLByAppendingPathComponent(URLHelper.deviceFileName)
-                    guard let devicePlist = NSDictionary(contentsOfURL: URL),
-                        UDID = devicePlist["UDID"] as? String,
-                        type = devicePlist["deviceType"] as? String,
-                        name = devicePlist["name"] as? String,
-                        runtime = devicePlist["runtime"] as? String,
-                        stateValue = devicePlist["state"] as? Int,
-                        state = Device.State(rawValue: stateValue) else {
-                            return nil
-                    }
-                    return Device(
-                        UDID: UDID,
-                        type: type,
-                        name: name,
-                        runtime: runtime,
-                        state: state
-                    )
-                }
-                mapping[key] = devices.filter { $0?.applications.count > 0 }.map { $0! }
-            }
-        }
-        deviceMapping = mapping
+    func shell(launchPath: String, arguments: [String]) -> String
+    {
+        let task = NSTask()
+        task.launchPath = launchPath
+        task.arguments = arguments
+        
+        let pipe = NSPipe()
+        task.standardOutput = pipe
+        task.launch()
+        
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: data, encoding: NSUTF8StringEncoding)!
+        
+        return output
     }
     
+    func reload2() {
+        // extract json from xcrun simctl list -j devices
+        // to get a list of devices
+        
+        var jsonString = shell("/usr/bin/xcrun", arguments: ["simctl", "list", "-j", "devices"]);
+        jsonString = jsonString.stringByReplacingOccurrencesOfString("\n", withString: "")
+        jsonString = jsonString.stringByTrimmingCharactersInSet(NSCharacterSet.newlineCharacterSet())
+        let data: NSData = jsonString.dataUsingEncoding(NSUTF8StringEncoding)!
+        
+        // array of devices to return
+        var mapping = [String: [Device]]()
+        
+        do {
+            if let json = try NSJSONSerialization.JSONObjectWithData(data, options:[]) as? [String: AnyObject] {
+                if let osVersions = json["devices"] as? [String:AnyObject] {
+                    
+                    // parse out only the iOS os
+                    // then parse through the devices for that OS
+                    let filtered = osVersions.filter { $0.0.containsString("iOS") }
+                    
+                    for os in filtered {
+                        // os.0 is iOS version ex "iOS 9.2"
+                        // os.1 is an array of devices
+                        
+                        // devices array to build
+                        // for sorting purposes
+                        var iPhones = [Device]()
+                        var iPads = [Device]()
+                        var otherDevices = [Device]()
+                        
+                        for device in os.1 as! [[String:String]] {
+                            var parsedState = Device.State.Unknown
+                            
+                            switch (device["state"]!) {
+                            case "Shutdown":
+                                parsedState = Device.State.Shutdown
+                                break;
+                            case "Booted":
+                                parsedState = Device.State.Booted
+                            default:
+                                parsedState = Device.State.Unknown
+                                break;
+                            }
+                            
+                            let newDevice = Device(
+                                UDID: device["udid"]!,
+                                type: device["name"]!,
+                                name: device["name"]!,
+                                runtime: os.0,
+                                state: parsedState
+                            )
+                            
+                            if (newDevice.name.hasPrefix("iPhone")) {
+                                iPhones.append(newDevice)
+                            }
+                            else if (newDevice.name.hasPrefix("iPad")) {
+                                iPads.append(newDevice)
+                            }
+                            else {
+                                otherDevices.append(newDevice)
+                            }
+                        }
+                        
+                        let sortedDevices = iPhones.reverse() + iPads.reverse() + otherDevices
+                        mapping[os.0] = sortedDevices.filter { $0.applications.count > 0 }.map { $0 }
+                    }
+                }
+            }
+        }
+        catch let parseError {
+            print(parseError)
+        }
+        
+        // sort so it appears
+        // in similar order that Xcode dispalys simulators
+        
+        // old iOS
+        // oldest iPads
+        // newest iPads
+        // oldest iPhones
+        // newer iPhones
+        for str in mapping.keys.sort() {
+            if let map = mapping[str] {
+                for dev:Device in map.reverse() {
+                    deviceMapping.append(dev)
+                }
+            }
+        }
+    }
 }

--- a/OpenSim/Runtime.swift
+++ b/OpenSim/Runtime.swift
@@ -13,6 +13,16 @@ struct Runtime: CustomStringConvertible {
     let name: String
     
     var description: String {
+        // current version is format "iOS major.minir"
+        // old versions of iOS are com.Apple.CoreSimulator.SimRuntime.iOS-major-minor
+        
+        // current version, parse out iOS
+        if name.hasPrefix("iOS ") {
+            let index = name.startIndex.advancedBy(4)
+            return name.substringFromIndex(index)
+        }
+        
+        // older version parsing
         if let components = name.componentsSeparatedByString(".").last?.componentsSeparatedByString("-") {
             return components[1..<components.count].joinWithSeparator(".")
         }


### PR DESCRIPTION
- parsed devices using xcrun as suggested by the TODO
- modified sort order to behave similar to Xcode's simulator list
- changed to run on OS X 10.10

![image](https://cloud.githubusercontent.com/assets/15929674/13452462/f036e0b6-e015-11e5-9cf6-2eaf26e4a418.png)
