### PR TITLE
add separator for iOS versions

### DIFF
--- a/OpenSim/MenuManager.swift
+++ b/OpenSim/MenuManager.swift
@@ -58,7 +58,13 @@ protocol MenuManagerDelegate {
         
         DeviceManager.defaultManager.reload()
         
+        var currentRuntime = ""
         DeviceManager.defaultManager.deviceMapping.forEach { device in
+            if (currentRuntime != "" && device.runtime.name != currentRuntime) {
+                menu.addItem(NSMenuItem.separatorItem())
+            }
+            currentRuntime = device.runtime.name
+            
             if let deviceMenuItem = menu.addItemWithTitle("\(device.name) (\(device.runtime))", action: nil, keyEquivalent: "") {
                 deviceMenuItem.onStateImage = NSImage(named: "active")
                 deviceMenuItem.offStateImage = NSImage(named: "inactive")


### PR DESCRIPTION
I originally had this in https://github.com/luosheng/OpenSim/pull/2 but noticed it was removed in the MenuManager commit.  I thought it might have been intentional so I created a separate PR for this minor UI change.

IMO it looks a bit better with more iOS versions but I won't be heartbroken if you want to just close this PR.
![image](https://cloud.githubusercontent.com/assets/15929674/16068227/4b09e924-3292-11e6-8a2e-89c11fccc470.png)
