### PR TITLE
check for booted simulator before uninstalling

### DIFF
--- a/OpenSim/MenuManager.swift
+++ b/OpenSim/MenuManager.swift
@@ -76,12 +76,14 @@ protocol MenuManagerDelegate {
                         appMenuItem.representedObject = DeviceApplicationPair(device: device, application: app)
                         appMenuItem.target = self
                         
-                        if let controlItem = submenu.addItemWithTitle("Uninstall \(app.bundleDisplayName)", action: #selector(appMenuItemClicked(_:)), keyEquivalent: "") {
-                            controlItem.representedObject = DeviceApplicationPair(device: device, application: app)
-                            controlItem.target = self
-                            
-                            controlItem.alternate = true
-                            controlItem.keyEquivalentModifierMask = Int(NSEventModifierFlags.ControlKeyMask.rawValue)
+                        if (device.state == .Booted) {
+                            if let controlItem = submenu.addItemWithTitle("Uninstall \(app.bundleDisplayName)", action: #selector(appMenuItemClicked(_:)), keyEquivalent: "") {
+                                controlItem.representedObject = DeviceApplicationPair(device: device, application: app)
+                                controlItem.target = self
+                                
+                                controlItem.alternate = true
+                                controlItem.keyEquivalentModifierMask = Int(NSEventModifierFlags.ControlKeyMask.rawValue)
+                            }
                         }
                     }
                     deviceMenuItem.submenu = submenu


### PR DESCRIPTION
since uninstalling on a non booted device causes a simctl error, I added an additional check.  I tested and this works when changing devices as well
