### PR TITLE
List device async

### DIFF
--- a/OpenSim/DeviceManager.swift
+++ b/OpenSim/DeviceManager.swift
@@ -17,7 +17,10 @@ final class DeviceManager {
     
     var runtimes = [Runtime]()
     
-    func reload() {
-        self.runtimes = SimulatorController.listDevices()
+    func reload(callback: ([Runtime]) -> ()) {
+        SimulatorController.listDevices { (runtimes) in
+            self.runtimes = runtimes
+            callback(runtimes)
+        }
     }
 }

--- a/OpenSim/DeviceManager.swift
+++ b/OpenSim/DeviceManager.swift
@@ -17,7 +17,7 @@ final class DeviceManager {
     
     var runtimes = [Runtime]()
     
-    func reload(callback: ([Runtime]) -> ()) {
+    func reload(callback: @escaping ([Runtime]) -> ()) {
         SimulatorController.listDevices { (runtimes) in
             self.runtimes = runtimes
             callback(runtimes)

--- a/OpenSim/Helper.swift
+++ b/OpenSim/Helper.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-func shell(_ launchPath: String, arguments: [String]) -> String? {
+func shell(_ launchPath: String, arguments: [String]) -> String {
     let progress = Process()
     progress.launchPath = launchPath
     progress.arguments = arguments
@@ -21,5 +21,5 @@ func shell(_ launchPath: String, arguments: [String]) -> String? {
     let data = pipe.fileHandleForReading.readDataToEndOfFile()
     let output = String(data: data, encoding: String.Encoding.utf8)
     
-    return output
+    return output ?? ""
 }

--- a/OpenSim/Helper.swift
+++ b/OpenSim/Helper.swift
@@ -15,6 +15,7 @@ func shell(_ launchPath: String, arguments: [String]) -> String? {
     
     let pipe = Pipe()
     progress.standardOutput = pipe
+    progress.standardError = Pipe()
     progress.launch()
     
     let data = pipe.fileHandleForReading.readDataToEndOfFile()

--- a/OpenSim/MenuManager.swift
+++ b/OpenSim/MenuManager.swift
@@ -99,7 +99,7 @@ protocol MenuManagerDelegate {
             let quitMenu = menu.addItem(withTitle: NSLocalizedString("Quit", comment: ""), action: #selector(self.quitItemClicked(_:)), keyEquivalent: "q")
             quitMenu.target = self
             
-            statusItem.menu = menu
+            self.statusItem.menu = menu
         }
     }
 

--- a/OpenSim/MenuManager.swift
+++ b/OpenSim/MenuManager.swift
@@ -54,53 +54,53 @@ protocol MenuManagerDelegate {
     private func buildMenu() {
         let menu = NSMenu()
         
-        DeviceManager.defaultManager.reload()
-
-        DeviceManager.defaultManager.runtimes.forEach { (runtime) in
-            let devices = runtime.devices.filter { $0.applications?.count ?? 0 > 0 }
-            if devices.count == 0 {
-                return
-            }
-            menu.addItem(NSMenuItem.separator())
-            let titleItem = NSMenuItem(title: "\(runtime) Simulators", action: nil, keyEquivalent: "")
-            titleItem.isEnabled = false
-            menu.addItem(titleItem)
-            
-            devices.forEach({ (device) in
-                let deviceMenuItem = menu.addItem(withTitle: device.fullName, action: nil, keyEquivalent: "")
-                deviceMenuItem.onStateImage = NSImage(named: "active")
-                deviceMenuItem.offStateImage = NSImage(named: "inactive")
-                deviceMenuItem.state = device.state == .Booted ? NSOnState : NSOffState
-                
-                let submenu = NSMenu()
-                submenu.delegate = self
-                device.applications?.forEach { app in
-                    let appMenuItem = AppMenuItem(application: app)
-                    appMenuItem.submenu = ActionMenu(device: device, application: app)
-                    submenu.addItem(appMenuItem)
+        DeviceManager.defaultManager.reload { (runtimes) in
+            runtimes.forEach { (runtime) in
+                let devices = runtime.devices.filter { $0.applications?.count ?? 0 > 0 }
+                if devices.count == 0 {
+                    return
                 }
-                deviceMenuItem.submenu = submenu
-            })
+                menu.addItem(NSMenuItem.separator())
+                let titleItem = NSMenuItem(title: "\(runtime) Simulators", action: nil, keyEquivalent: "")
+                titleItem.isEnabled = false
+                menu.addItem(titleItem)
+
+                devices.forEach({ (device) in
+                    let deviceMenuItem = menu.addItem(withTitle: device.fullName, action: nil, keyEquivalent: "")
+                    deviceMenuItem.onStateImage = NSImage(named: "active")
+                    deviceMenuItem.offStateImage = NSImage(named: "inactive")
+                    deviceMenuItem.state = device.state == .Booted ? NSOnState : NSOffState
+
+                    let submenu = NSMenu()
+                    submenu.delegate = self
+                    device.applications?.forEach { app in
+                        let appMenuItem = AppMenuItem(application: app)
+                        appMenuItem.submenu = ActionMenu(device: device, application: app)
+                        submenu.addItem(appMenuItem)
+                    }
+                    deviceMenuItem.submenu = submenu
+                })
+
+            }
+
+            menu.addItem(NSMenuItem.separator())
+
+            let refreshMenuItem = menu.addItem(withTitle: NSLocalizedString("Refresh", comment: ""), action: #selector(self.refreshItemClicked(_:)), keyEquivalent: "r")
+            refreshMenuItem.target = self
+
+            let launchAtLoginMenuItem = menu.addItem(withTitle: NSLocalizedString("Launch at Login", comment: ""), action: #selector(self.launchItemClicked(_:)), keyEquivalent: "")
+            launchAtLoginMenuItem.target = self
+            if existingItem(itemUrl: Bundle.main.bundleURL) != nil {
+                launchAtLoginMenuItem.state = NSOnState
+            } else {
+                launchAtLoginMenuItem.state = NSOffState
+            }
+
+            let quitMenu = menu.addItem(withTitle: NSLocalizedString("Quit", comment: ""), action: #selector(self.quitItemClicked(_:)), keyEquivalent: "q")
+            quitMenu.target = self
             
+            statusItem.menu = menu
         }
-
-        menu.addItem(NSMenuItem.separator())
-
-        let refreshMenuItem = menu.addItem(withTitle: NSLocalizedString("Refresh", comment: ""), action: #selector(refreshItemClicked(_:)), keyEquivalent: "r")
-        refreshMenuItem.target = self
-        
-        let launchAtLoginMenuItem = menu.addItem(withTitle: NSLocalizedString("Launch at Login", comment: ""), action: #selector(launchItemClicked(_:)), keyEquivalent: "")
-        launchAtLoginMenuItem.target = self
-        if existingItem(itemUrl: Bundle.main.bundleURL) != nil {
-            launchAtLoginMenuItem.state = NSOnState
-        } else {
-            launchAtLoginMenuItem.state = NSOffState
-        }
-
-        let quitMenu = menu.addItem(withTitle: NSLocalizedString("Quit", comment: ""), action: #selector(quitItemClicked(_:)), keyEquivalent: "q")
-        quitMenu.target = self
-
-        statusItem.menu = menu
     }
 
     private func buildWatcher() {

--- a/OpenSim/SimulatorController.swift
+++ b/OpenSim/SimulatorController.swift
@@ -16,8 +16,8 @@ struct SimulatorController {
     }
 
     static func listDevices(callback: ([Runtime]) -> ()) {
-        guard let jsonString = shell("/usr/bin/xcrun", arguments: ["simctl", "list", "-j", "devices"]),
-            let data = jsonString.data(using: String.Encoding.utf8),
+        let jsonString = shell("/usr/bin/xcrun", arguments: ["simctl", "list", "-j", "devices"])
+        guard let data = jsonString.data(using: String.Encoding.utf8),
             let json = try? JSONSerialization.jsonObject(with: data, options:[]) as? [String: AnyObject],
             let devicesJson = json?["devices"] as? [String:AnyObject] else {
                 callback([])

--- a/OpenSim/SimulatorController.swift
+++ b/OpenSim/SimulatorController.swift
@@ -14,15 +14,16 @@ struct SimulatorController {
     static func uninstall(_ application: Application) {
         _ = shell("/usr/bin/xcrun", arguments: ["simctl", "uninstall", application.device.UDID, application.bundleID])
     }
-    
-    static func listDevices() -> [Runtime] {
+
+    static func listDevices(callback: ([Runtime]) -> ()) {
         guard let jsonString = shell("/usr/bin/xcrun", arguments: ["simctl", "list", "-j", "devices"]),
             let data = jsonString.data(using: String.Encoding.utf8),
             let json = try? JSONSerialization.jsonObject(with: data, options:[]) as? [String: AnyObject],
             let devicesJson = json?["devices"] as? [String:AnyObject] else {
-                return []
+                callback([])
+                return
         }
-        
+
         var runtimes = [Runtime]()
         for (runtimeName, deviceList) in devicesJson {
             let runtime = Runtime(name: runtimeName)
@@ -33,7 +34,7 @@ struct SimulatorController {
                         let name = deviceJson["name"],
                         let udid = deviceJson["udid"] {
                         let device = Device(udid: udid, type: name, name: name, state: state, availability: availability)
-                        
+
                         if device.availability == .available {
                             runtime.devices.append(device)
                         }
@@ -45,9 +46,9 @@ struct SimulatorController {
             }
             runtimes.append(runtime)
         }
-        
+
         let filteredRuntime = runtimes.filter { $0.name.contains("iOS") && $0.devices.count > 0 }
-        
-        return filteredRuntime
+
+        callback(filteredRuntime)
     }
 }

--- a/OpenSim/SimulatorController.swift
+++ b/OpenSim/SimulatorController.swift
@@ -51,4 +51,18 @@ struct SimulatorController {
 
         callback(filteredRuntime)
     }
+
+    private static let maxAttempt = 8
+
+    private static func getDevicesJson(currentAttempt: Int, callback: @escaping (String) -> ()) {
+        print(currentAttempt)
+        let jsonString = shell("/usr/bin/xcrun", arguments: ["simctl", "list", "-j", "devices"])
+        if jsonString.characters.count > 0 || currentAttempt >= maxAttempt {
+            callback(jsonString)
+            return
+        }
+        DispatchQueue.global().asyncAfter(deadline: .now() + 1) {
+            getDevicesJson(currentAttempt: currentAttempt + 1, callback: callback)
+        }
+    }
 }


### PR DESCRIPTION
This PR mainly targets for users who have run multiple Xcode's on a same machine.

Here's what happens if you run `xcrun simctl list -j devices` after opening an Xcode other than the one set by `xcode-select`:

> 2017-07-04 10:59:28.182 simctl[83676:78821853] CoreSimulator detected Xcode.app relocation or CoreSimulatorService version change.  Framework path (/Applications/Xcode.app/Contents/Developer/Library/PrivateFrameworks/CoreSimulator.framework) and version (375.21) does not match existing job path (/Library/Developer/PrivateFrameworks/CoreSimulator.framework/Versions/A/XPCServices/com.apple.CoreSimulator.CoreSimulatorService.xpc) and version (459.13).  Attempting to remove the stale service in order to add the expected version.

And `simctl` refuses to output any device information.

The fix is simple though: just run the command again in a few seconds. However this requires us to change the way OpenSim reloads the menu from synchronously to asynchronously.

This should fix #29 and fix #13 .