### PR TITLE
#34 fix "Copy Sandbox Path to Pasteboard" not working

### DIFF
--- a/OpenSim/CopyToPasteboardAction.swift
+++ b/OpenSim/CopyToPasteboardAction.swift
@@ -24,7 +24,9 @@ final class CopyToPasteboardAction: ApplicationActionable {
     
     func perform() {
         if let url = application?.sandboxUrl {
-            NSPasteboard.general.setString(url.path, forType: NSPasteboard.PasteboardType.string)
+            let pasteboard = NSPasteboard.general
+            pasteboard.declareTypes([NSPasteboard.PasteboardType.string], owner: nil)
+            pasteboard.setString(url.path, forType: NSPasteboard.PasteboardType.string)
         }
     }
     


### PR DESCRIPTION
Noticed copy to Pasteboard wasn't working so I fixed it.

Resolves #34 .