### PR TITLE
Fix uninstall on shutdown simulators

### DIFF
--- a/OpenSim/Application.swift
+++ b/OpenSim/Application.swift
@@ -80,6 +80,9 @@ final class Application {
     }
     
     func uninstall() {
+        if device.state != .Booted {
+            SimulatorController.boot(self)
+        }
         SimulatorController.uninstall(self)
     }
 }

--- a/OpenSim/SimulatorController.swift
+++ b/OpenSim/SimulatorController.swift
@@ -14,6 +14,10 @@ struct SimulatorController {
     static func uninstall(_ application: Application) {
         _ = shell("/usr/bin/xcrun", arguments: ["simctl", "uninstall", application.device.UDID, application.bundleID])
     }
+    
+    static func boot(_ application: Application) {
+        _ = shell("/usr/bin/xcrun", arguments: ["simctl", "boot", application.device.UDID])
+    }
 
     static func listDevices(callback: @escaping ([Runtime]) -> ()) {
         getDevicesJson(currentAttempt: 0) { (jsonString) in


### PR DESCRIPTION
If the simulator is shutdown the uninstall command doesn’t work. This fix checks for the simulator status and boots it if necessary.

Running the uninstall command on a shutdown simulator returns the following:

```
xcrun simctl uninstall 1E09A9DA-B8EE-44E5-8BA7-74F9A63CA147 com.test.app
An error was encountered processing the command (domain=com.apple.CoreSimulator.SimError, code=164):
Unable to lookup in current state: Shutdown
```

I noticed the issue when I was trying to uninstall some apps and it wasn't working.
Since it's a sync request it can take a while for the uninstall to happen, but I figured that it's better to have a long action that works than a quick one that wasn't working :) 

Maybe this could be improved using background queues, but I'm afraid that some new UX would be required for that so the user understands why the command returned but nothing happened.