### PR TITLE
Fix device parser on Xcode 10.1

### DIFF
--- a/OpenSim/SimulatorController.swift
+++ b/OpenSim/SimulatorController.swift
@@ -31,12 +31,12 @@ struct SimulatorController {
             var runtimes = [Runtime]()
             devicesJson.forEach({ (runtimeName, deviceList) in
                 let runtime = Runtime(name: runtimeName)
-                if let deviceList = deviceList as? [[String:String]] {
+                if let deviceList = deviceList as? [[String:AnyObject]] {
                     for deviceJson in deviceList {
-                        if let state = deviceJson["state"],
-                            let availability = deviceJson["availability"],
-                            let name = deviceJson["name"],
-                            let udid = deviceJson["udid"] {
+                        if let state = deviceJson["state"] as? String,
+                            let availability = deviceJson["availability"] as? String,
+                            let name = deviceJson["name"] as? String,
+                            let udid = deviceJson["udid"] as? String {
                             let device = Device(udid: udid, type: name, name: name, state: state, availability: availability)
 
                             if device.availability == .available {


### PR DESCRIPTION
On Xcode 10.1 there’s a new property on the device json which is not a String:
 "isAvailable" : true,

This was causing the parser to fail due the [[String:String]] casting.

I changed it to [[String:AnyObject]] and added String casts on the if let.

Ideally this would be solved using codable, but it would require a bigger refactor. I might give it a shot later but I wanted a quick fix to keep using this ASAP :)